### PR TITLE
Fixing the spelling of 'mapping' in the comments.

### DIFF
--- a/src/javascript/analytics.js
+++ b/src/javascript/analytics.js
@@ -87,7 +87,7 @@ export const gaTest = createGaProxy(TEST_TRACKERS);
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom dimension names and their indexes.
  */
 export const dimensions = {
   BREAKPOINT: 'dimension1',
@@ -109,7 +109,7 @@ export const dimensions = {
 
 
 /**
- * A maping between custom dimension names and their indexes.
+ * A mapping between custom dimension names and their indexes.
  */
 export const metrics = {
   QUERY_SUCCESS: 'metric1',


### PR DESCRIPTION
This source is displayed on a public-facing documentation page for Google Analytics, so I figured I'd help out and fix the spelling.